### PR TITLE
GitHub Workflow for automated release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,23 +14,12 @@ jobs:
       with:
         submodules: recursive
         
-    - name: Install build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y gcc make
-        
     - name: Build rewindtty
       run: make
-      
-    - name: Generate SHA256 checksum
-      run: |
-        cd build
-        sha256sum rewindtty > rewindtty.sha256
         
     - name: Upload binary to release
       run: |
         gh release upload ${{ github.event.release.tag_name }} \
-          ./build/rewindtty#rewindtty-linux-x86_64 \
-          ./build/rewindtty.sha256#rewindtty-linux-x86_64.sha256
+          ./build/rewindtty#rewindtty-linux-x86_64
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Build and Attach Release Assets
+
+on:
+  release:
+    types: [published, prereleased]
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc make
+        
+    - name: Build rewindtty
+      run: make
+      
+    - name: Generate SHA256 checksum
+      run: |
+        cd build
+        sha256sum rewindtty > rewindtty.sha256
+        
+    - name: Upload binary to release
+      run: |
+        gh release upload ${{ github.event.release.tag_name }} \
+          ./build/rewindtty#rewindtty-linux-x86_64 \
+          ./build/rewindtty.sha256#rewindtty-linux-x86_64.sha256
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I use [eget](https://github.com/zyedidia/eget) to download binaries from GitHub for tools that aren't part of Linux distributions, so I've made a workflow that builds the binary when new releases are made.

Initial commit made by Copilot, than cleaned up a bit to remove redundancies.