### PR TITLE
fix: improve memory safety and robust file reading (#6)

### DIFF
--- a/src/analyzer.c
+++ b/src/analyzer.c
@@ -13,10 +13,11 @@ static const char *error_keywords[] = {
 
 static int has_error_indicators(const char *data)
 {
-
     if (!data)
         return 0;
     char *lower_data = to_lower(data);
+    if (!lower_data)
+        return 0; 
 
     int has_errors = 0;
     for (size_t i = 0; i < (sizeof(error_keywords) / sizeof(error_keywords[0])); i++)
@@ -77,6 +78,11 @@ static void count_command_frequency(CommandInfo *commands, int count, CommandInf
         if (!found && freq_count < 1000)
         {
             freq_table[freq_count].command = strdup(commands[i].command);
+            if (!freq_table[freq_count].command)
+            {
+                fprintf(stderr, "Error: Out of memory duplicating command for frequency table\n");
+                continue; // Skip this command
+            }
             freq_table[freq_count].frequency = 1;
             freq_table[freq_count].total_duration = commands[i].duration;
             freq_count++;
@@ -101,7 +107,20 @@ static void count_command_frequency(CommandInfo *commands, int count, CommandInf
     for (int i = 0; i < *top_count; i++)
     {
         top_commands[i] = malloc(sizeof(CommandInfo));
+        if (!top_commands[i])
+        {
+            fprintf(stderr, "Error: Out of memory allocating top command\n");
+            top_commands[i] = NULL;
+            continue; // Skip
+        }
         top_commands[i]->command = strdup(freq_table[i].command);
+        if (!top_commands[i]->command)
+        {
+            fprintf(stderr, "Error: Out of memory duplicating command for top command\n");
+            free(top_commands[i]);
+            top_commands[i] = NULL;
+            continue;
+        }
         top_commands[i]->duration = freq_table[i].total_duration;
         top_commands[i]->chunk_count = freq_table[i].frequency; // Using chunk_count as frequency
     }
@@ -130,6 +149,8 @@ void analyze_session(const char *session_file)
     }
 
     cJSON *sessions_array = NULL;
+    SessionAnalysis analysis = {0};
+    CommandInfo *sorted_by_duration = NULL;
     
     // Check if this is the new format with metadata
     if (cJSON_IsObject(json))
@@ -141,9 +162,7 @@ void analyze_session(const char *session_file)
             if (interactive_mode && cJSON_IsBool(interactive_mode) && cJSON_IsTrue(interactive_mode))
             {
                 fprintf(stderr, "Error: Analyze is currently unavailable in interactive mode\n");
-                cJSON_Delete(json);
-                free(json_string);
-                return;
+                goto cleanup; 
             }
         }
         
@@ -151,9 +170,7 @@ void analyze_session(const char *session_file)
         if (!sessions_array || !cJSON_IsArray(sessions_array))
         {
             fprintf(stderr, "Error: Session file should contain a 'sessions' array\n");
-            cJSON_Delete(json);
-            free(json_string);
-            return;
+            goto cleanup;
         }
     }
     else if (cJSON_IsArray(json))
@@ -164,15 +181,18 @@ void analyze_session(const char *session_file)
     else
     {
         fprintf(stderr, "Error: Session file should contain an array of commands or a metadata object\n");
-        cJSON_Delete(json);
-        free(json_string);
-        return;
+        goto cleanup;
     }
 
-    SessionAnalysis analysis = {0};
     int array_size = cJSON_GetArraySize(sessions_array);
     analysis.total_commands = array_size;
     analysis.commands = malloc(array_size * sizeof(CommandInfo));
+    if (!analysis.commands)
+    {
+        fprintf(stderr, "Error: cannot allocate memory for %d commands\n", array_size);
+        goto cleanup; 
+    }
+    memset(analysis.commands, 0, array_size * sizeof(CommandInfo));
 
     double total_duration = 0;
     double first_start_time = -1;
@@ -193,6 +213,11 @@ void analyze_session(const char *session_file)
         if (command && start_time && end_time && duration)
         {
             analysis.commands[i].command = strdup(cJSON_GetStringValue(command));
+            if (!analysis.commands[i].command)
+            {
+                fprintf(stderr, "Error: out of memory duplicating command string\n");
+                goto cleanup; 
+            }
             analysis.commands[i].start_time = cJSON_GetNumberValue(start_time);
             analysis.commands[i].end_time = cJSON_GetNumberValue(end_time);
             analysis.commands[i].duration = cJSON_GetNumberValue(duration);
@@ -220,6 +245,11 @@ void analyze_session(const char *session_file)
                     if (data && has_error_indicators(cJSON_GetStringValue(data)))
                     {
                         analysis.commands[i].stderr_data = strdup(cJSON_GetStringValue(data));
+                        if (!analysis.commands[i].stderr_data)
+                        {
+                            fprintf(stderr, "Error: out of memory duplicating stderr data\n");
+                            goto cleanup;
+                        }
                         analysis.commands[i].has_stderr = 1;
                         analysis.commands_with_stderr++;
                         break;
@@ -240,7 +270,12 @@ void analyze_session(const char *session_file)
                             analysis.top_commands, &analysis.top_commands_count);
 
     // Find slowest commands
-    CommandInfo *sorted_by_duration = malloc(analysis.total_commands * sizeof(CommandInfo));
+    sorted_by_duration = malloc(analysis.total_commands * sizeof(CommandInfo));
+    if (!sorted_by_duration)
+    {
+        fprintf(stderr, "Error: cannot allocate memory for sorting buffer\n");
+        goto cleanup;
+    }
     memcpy(sorted_by_duration, analysis.commands, analysis.total_commands * sizeof(CommandInfo));
 
     for (int i = 0; i < analysis.total_commands - 1; i++)
@@ -276,11 +311,7 @@ void analyze_session(const char *session_file)
     print_session_summary(&analysis);
 
     // Cleanup
-    for (int i = 0; i < analysis.top_commands_count; i++)
-    {
-        free(analysis.top_commands[i]->command);
-        free(analysis.top_commands[i]);
-    }
+cleanup: 
     free(sorted_by_duration);
     free_session_analysis(&analysis);
     cJSON_Delete(json);
@@ -340,12 +371,39 @@ void print_session_summary(SessionAnalysis *analysis)
 
 void free_session_analysis(SessionAnalysis *analysis)
 {
+    if (!analysis)
+        return; 
+
+    // Free individual commands
     if (analysis->commands)
     {
         for (int i = 0; i < analysis->total_commands; i++)
         {
             free(analysis->commands[i].command);
+            free(analysis->commands[i].stderr_data);
         }
         free(analysis->commands);
+        analysis->commands = NULL; 
     }
+
+    // Free top commands
+    for (int i = 0; i < analysis->top_commands_count; i++)
+    {
+        if (analysis->top_commands[i])
+        {
+            free(analysis->top_commands[i]->command);
+            free(analysis->top_commands[i]);
+            analysis->top_commands[i] = NULL;
+        }
+    }
+    analysis->top_commands_count = 0;
+
+    // Reset other fields
+    analysis->total_commands = 0;
+    analysis->commands_with_stderr = 0;
+    analysis->total_duration = 0;
+    analysis->avg_time_per_command = 0;
+    analysis->stderr_percentage = 0;
+    analysis->slowest_commands_count = 0;
+    analysis->error_commands_count = 0;
 }

--- a/src/recorder.c
+++ b/src/recorder.c
@@ -38,11 +38,18 @@ double get_timestamp()
 TTYSession *create_tty_session(const char *command)
 {
     TTYSession *session = malloc(sizeof(TTYSession));
+    if (!session)
+        return NULL;
     strncpy(session->command, command, sizeof(session->command) - 1);
     session->command[sizeof(session->command) - 1] = '\0';
     session->start_time = get_timestamp();
     session->end_time = 0;
     session->chunks = malloc(sizeof(TTYChunk) * 100);
+    if (!session->chunks)
+    {
+        free(session); 
+        return NULL;
+    }
     session->chunk_count = 0;
     session->chunk_capacity = 100;
     return session;
@@ -117,7 +124,14 @@ void free_tty_session(TTYSession *session)
 SessionData *create_session_data(int interactive_mode)
 {
     SessionData *data = malloc(sizeof(SessionData));
+    if (!data)
+        return NULL; 
     data->sessions = malloc(sizeof(TTYSession *) * 10);
+    if (!data->sessions)
+    {
+        free(data);
+        return NULL;
+    }
     data->session_count = 0;
     data->session_capacity = 10;
     data->interactive_mode = interactive_mode;
@@ -215,6 +229,11 @@ TTYSession *exec_and_capture_pty_realtime(
     pid_t pid;
     struct termios term_attrs, raw_attrs;
     TTYSession *session = create_tty_session(command);
+    if (!session)
+    {
+        fprintf(stderr, "Failed to create TTY session\n"); 
+        return NULL;
+    }
 
     if (tcgetattr(STDIN_FILENO, &term_attrs) != 0)
     {
@@ -367,8 +386,15 @@ void signal_handler(int signal)
 InputBuffer *create_input_buffer()
 {
     InputBuffer *buf = malloc(sizeof(InputBuffer));
+    if (!buf)
+        return NULL;
     buf->capacity = 1024;
     buf->buffer = malloc(buf->capacity);
+    if (!buf->buffer)
+    {
+        free(buf);
+        return NULL;
+    }
     buf->size = 0;
     return buf;
 }
@@ -447,7 +473,19 @@ void start_interactive_recording(const char *filename)
 
     // Initialize session data
     global_session_data = create_session_data(1); // interactive mode
+    if (!global_session_data)
+    {
+        fprintf(stderr, "Failed to create a session\n");
+        return; 
+    }
     current_filename = strdup(filename);
+    if (!current_filename)
+    {
+        fprintf(stderr, "Error: out of memory for filename\n");
+        free_session_data(global_session_data);
+        global_session_data = NULL; 
+        return; 
+    }
 
     const char *shell_path = getenv("SHELL");
     if (!shell_path)
@@ -456,9 +494,12 @@ void start_interactive_recording(const char *filename)
     printf("Interactive TTY recording started. Use your shell normally.\n");
     printf("Press Ctrl+D or type 'exit' to stop recording.\n");
 
-    int master_fd;
-    pid_t pid;
+    int master_fd = -1;
+    pid_t pid = -1;
     struct termios term_attrs, raw_attrs;
+    InputBuffer *input_buf = NULL;
+    InputBuffer *output_buf = NULL;
+    TTYSession *current_session = NULL;
 
     if (tcgetattr(STDIN_FILENO, &term_attrs) != 0)
     {
@@ -506,9 +547,19 @@ void start_interactive_recording(const char *filename)
         fcntl(master_fd, F_SETFL, flags | O_NONBLOCK);
 
         // Command detection variables
-        InputBuffer *input_buf = create_input_buffer();
-        InputBuffer *output_buf = create_input_buffer();
-        TTYSession *current_session = NULL;
+        input_buf = create_input_buffer();
+        if (!input_buf)
+        {
+            fprintf(stderr, "Error: failed to create input buffer\n");
+            goto cleanup; 
+        }
+        output_buf = create_input_buffer();
+        if (!output_buf)
+        {
+            fprintf(stderr, "Error: failed to create output buffer\n");
+            goto cleanup;  
+        }
+
         int in_command = 0;
         int waiting_for_prompt = 1;
 
@@ -588,6 +639,10 @@ void start_interactive_recording(const char *filename)
 
                             // Start new session
                             current_session = create_tty_session(command_str);
+                            if (!current_session)
+                            {
+                                fprintf(stderr, "Warning: failed to create TTY session\n"); 
+                            }
                             in_command = 1;
                         }
 
@@ -637,13 +692,19 @@ void start_interactive_recording(const char *filename)
             waitpid(pid, &status, 0);
         }
 
-        close(master_fd);
-        child_running = 0;
-        current_child_pid = 0;
-
-        free_input_buffer(input_buf);
-        free_input_buffer(output_buf);
     }
+
+cleanup: 
+    if (master_fd >= 0)
+        close(master_fd); 
+
+    child_running = 0; 
+    current_child_pid = 0;
+
+    if (input_buf)
+        free_input_buffer(input_buf);
+    if (output_buf)
+        free_input_buffer(output_buf);
 
     // Write final JSON file
     write_sessions_to_file(filename, global_session_data);
@@ -669,7 +730,19 @@ void start_recording(const char *filename)
 
     // Initialize session data
     global_session_data = create_session_data(0); // non-interactive mode
+    if (!global_session_data)
+    {
+        fprintf(stderr, "Failed to create a session\n");
+        return; 
+    }
     current_filename = strdup(filename);
+    if (!current_filename)
+    {
+        fprintf(stderr, "Error: out of memory for filename\n");
+        free_session_data(global_session_data);
+        global_session_data = NULL; 
+        return; 
+    }
 
     printf("TTY Real-time Recorder started. Type 'exit' to quit.\n");
 

--- a/src/replayer.c
+++ b/src/replayer.c
@@ -92,6 +92,8 @@ char *decode_escaped_sequences(const char *input)
 
     size_t len = strlen(input);
     char *output = malloc(len * 2); // Extra space for safety
+    if (!output)
+        return NULL;
     size_t out_pos = 0;
     size_t i = 0;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -17,26 +17,46 @@ char *to_lower(const char *str)
 
 char *read_file(const char *filename)
 {
-    FILE *file = fopen(filename, "r");
+    FILE *file = fopen(filename, "rb");
     if (!file)
     {
-        fprintf(stderr, "Error: Cannot open file '%s'\n", filename);
+        perror(filename); 
         return NULL;
     }
 
-    fseek(file, 0, SEEK_END);
+    if (fseek(file, 0, SEEK_END))
+    {
+        perror("fseek"); 
+        fclose(file);
+        return NULL; 
+    }
+
     long file_size = ftell(file);
+    if (file_size < 0)
+    {
+        perror("ftell"); 
+        fclose(file);
+        return NULL;
+    }
     rewind(file);
 
     char *content = malloc(file_size + 1);
     if (!content)
     {
+        fprintf(stderr, "Error cannot allocate %ld bytes", file_size);
         fclose(file);
         return NULL;
     }
 
-    fread(content, 1, file_size, file);
-    content[file_size] = '\0';
+    size_t bytes_read = fread(content, 1, file_size, file);
     fclose(file);
+    if (bytes_read != (size_t)file_size)
+    {
+        fprintf(stderr, "Error: fread failed (read %zu / %ld)\n", bytes_read, file_size);
+        free(content); 
+        return NULL;
+    }
+
+    content[file_size] = '\0';
     return content;
 }


### PR DESCRIPTION
- Added NULL checks after malloc, realloc, and strdup in recorder.c, replayer.c, and analyzer.c
- Enhanced read_file() in utils.c to handle errors more robustly
- These changes improve overall safety but do not fully eliminate all memory risks in the codebase.

Issue: References [#6]